### PR TITLE
Index Store

### DIFF
--- a/diskindexstore.go
+++ b/diskindexstore.go
@@ -1,6 +1,9 @@
 package simian
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -11,47 +14,47 @@ type DiskIndexStore struct {
 	RootPath string
 }
 
-func (s *DiskIndexStore) GetNode(path string) (*IndexNode, error) {
-	_, err := os.Stat(path)
+func (s *DiskIndexStore) GetChild(f Fingerprint, parent *IndexNode) (*IndexNode, error) {
+	path := s.childPathForFingerprint(f, parent.path)
+	return s.getNodeByPath(path)
+}
+
+func (s *DiskIndexStore) GetOrCreateChild(f Fingerprint, parent *IndexNode) (*IndexNode, error) {
+	fmt.Printf("GetOrCreateChild()\n")
+	childPath := s.childPathForFingerprint(f, parent.path)
+
+	node, err := s.getNodeByPath(childPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
+		return nil, err
+	}
+
+	if node == nil {
+		fmt.Printf("Creating child\n")
+
+		node = &IndexNode{
+			path: childPath,
+			childrenByFingerprint: make(map[string]*IndexNodeHandle),
 		}
-		return nil, err
-	}
 
-	node := &IndexNode{
-		path: path,
-		childrenByFingerprint: make(map[string]*IndexNodeHandle),
-	}
+		err := s.saveNode(node, f)
+		if err != nil {
+			return nil, err
+		}
 
-	err = s.loadAllChildren(node)
-	if err != nil {
-		return nil, err
+		parent.registerChild(node, f)
 	}
 
 	return node, nil
 }
 
 func (s *DiskIndexStore) GetRoot() (*IndexNode, error) {
-	return s.GetNode(s.RootPath)
+	return s.getNodeByPath(s.RootPath)
 }
 
-func (s *DiskIndexStore) SaveNode(n *IndexNode, f Fingerprint) (err error) {
-
-	os.Mkdir(n.path, os.FileMode(0522))
-
-	// Save the actual (non-truncated) fingerprint
-	fingerprintFile := filepath.Join(n.path, nodeFingerprintFile)
-	file, err := os.Create(fingerprintFile)
-	if err != nil {
-		return
-	}
-
-	defer file.Close()
-
-	_, err = file.Write(f.Bytes())
-	return
+func (s *DiskIndexStore) childPathForFingerprint(f Fingerprint, parentPath string) string {
+	fingerprintHash := sha256.Sum256(f.Bytes())
+	childDirName := hex.EncodeToString(fingerprintHash[:8])
+	return filepath.Join(parentPath, childDirName)
 }
 
 func (s *DiskIndexStore) fingerprintForChild(childPath string) (Fingerprint, error) {
@@ -78,6 +81,29 @@ func (s *DiskIndexStore) fingerprintForChild(childPath string) (Fingerprint, err
 	childFingerprint.UnmarshalBytes(fingerprintBytes)
 
 	return childFingerprint, nil
+}
+
+func (s *DiskIndexStore) getNodeByPath(path string) (*IndexNode, error) {
+
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	node := &IndexNode{
+		path: path,
+		childrenByFingerprint: make(map[string]*IndexNodeHandle),
+	}
+
+	err = s.loadAllChildren(node)
+	if err != nil {
+		return nil, err
+	}
+
+	return node, nil
 }
 
 func (s *DiskIndexStore) loadAllChildren(n *IndexNode) error {
@@ -111,4 +137,22 @@ func (s *DiskIndexStore) loadChild(n *IndexNode, childDirName string) (*IndexNod
 	}
 
 	return &IndexNodeHandle{Path: childPath, Fingerprint: childFingerprint}, nil
+}
+
+func (s *DiskIndexStore) saveNode(n *IndexNode, f Fingerprint) error {
+	fmt.Printf("Saving node %s\n", n.path)
+
+	os.Mkdir(n.path, os.FileMode(0700))
+
+	// Save the actual (non-truncated) fingerprint
+	fingerprintFile := filepath.Join(n.path, nodeFingerprintFile)
+	file, err := os.Create(fingerprintFile)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	_, err = file.Write(f.Bytes())
+	return err
 }

--- a/diskindexstore.go
+++ b/diskindexstore.go
@@ -8,10 +8,15 @@ import (
 const nodeFingerprintFile = "fingerprint"
 
 type DiskIndexStore struct {
+	RootPath string
 }
 
 func (s *DiskIndexStore) GetNode(h *IndexNodeHandle) (*IndexNode, error) {
 	return &IndexNode{path: h.Path}, nil
+}
+
+func (s *DiskIndexStore) GetRoot() *IndexNode {
+	return &IndexNode{path: s.RootPath}
 }
 
 func (s *DiskIndexStore) SaveNode(n *IndexNode, f Fingerprint) (err error) {

--- a/diskindexstore.go
+++ b/diskindexstore.go
@@ -1,0 +1,32 @@
+package simian
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const nodeFingerprintFile = "fingerprint"
+
+type DiskIndexStore struct {
+}
+
+func (s *DiskIndexStore) GetNode(h *IndexNodeHandle) (*IndexNode, error) {
+	return &IndexNode{path: h.Path}, nil
+}
+
+func (s *DiskIndexStore) SaveNode(n *IndexNode, f Fingerprint) (err error) {
+
+	os.Mkdir(n.path, os.FileMode(0522))
+
+	// Save the actual (non-truncated) fingerprint
+	fingerprintFile := filepath.Join(n.path, nodeFingerprintFile)
+	file, err := os.Create(fingerprintFile)
+	if err != nil {
+		return
+	}
+
+	defer file.Close()
+
+	_, err = file.Write(f.Bytes())
+	return
+}

--- a/diskindexstore.go
+++ b/diskindexstore.go
@@ -9,9 +9,17 @@ import (
 )
 
 const nodeFingerprintFile = "fingerprint"
+const nodeEntriesDir = "entries"
 
 type DiskIndexStore struct {
 	RootPath string
+}
+
+func (s *DiskIndexStore) AddEntry(entry *IndexEntry, node *IndexNode) error {
+	entriesDir := filepath.Join(node.path, nodeEntriesDir)
+	os.Mkdir(entriesDir, os.ModePerm)
+
+	return entry.saveToDir(entriesDir)
 }
 
 func (s *DiskIndexStore) GetChild(f Fingerprint, parent *IndexNode) (*IndexNode, error) {
@@ -49,6 +57,11 @@ func (s *DiskIndexStore) GetOrCreateChild(f Fingerprint, parent *IndexNode) (*In
 
 func (s *DiskIndexStore) GetRoot() (*IndexNode, error) {
 	return s.getNodeByPath(s.RootPath)
+}
+
+func (s *DiskIndexStore) RemoveEntries(node *IndexNode) error {
+	entriesDir := filepath.Join(node.path, nodeEntriesDir)
+	return os.RemoveAll(entriesDir)
 }
 
 func (s *DiskIndexStore) childPathForFingerprint(f Fingerprint, parentPath string) string {

--- a/diskindexstore.go
+++ b/diskindexstore.go
@@ -12,12 +12,20 @@ type DiskIndexStore struct {
 }
 
 func (s *DiskIndexStore) GetNode(path string) (*IndexNode, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
 	node := &IndexNode{
 		path: path,
 		childrenByFingerprint: make(map[string]*IndexNodeHandle),
 	}
 
-	err := s.loadAllChildren(node)
+	err = s.loadAllChildren(node)
 	if err != nil {
 		return nil, err
 	}

--- a/diskindexstore.go
+++ b/diskindexstore.go
@@ -11,8 +11,8 @@ type DiskIndexStore struct {
 	RootPath string
 }
 
-func (s *DiskIndexStore) GetNode(h *IndexNodeHandle) (*IndexNode, error) {
-	return &IndexNode{path: h.Path}, nil
+func (s *DiskIndexStore) GetNode(path string, f Fingerprint) (*IndexNode, error) {
+	return &IndexNode{path: path}, nil
 }
 
 func (s *DiskIndexStore) GetRoot() *IndexNode {

--- a/index.go
+++ b/index.go
@@ -11,7 +11,6 @@ const rootFingerprintSize = 1
 
 type Index struct {
 	Store              IndexStore
-	rootNode           IndexNode
 	maxFingerprintSize int
 	maxEntryDifference float64
 }
@@ -22,7 +21,7 @@ func (i *Index) Add(image image.Image, metadata interface{}) (key string, err er
 		return "", nil
 	}
 
-	node, err := i.rootNode.Add(entry, rootFingerprintSize+1, i)
+	node, err := i.Store.GetRoot().Add(entry, rootFingerprintSize+1, i)
 	if err != nil {
 		return "", err
 	}
@@ -36,7 +35,7 @@ func (i *Index) FindNearest(image image.Image, maxResults int, maxDifference flo
 		return nil, nil
 	}
 
-	results, err := i.rootNode.FindNearest(entry, rootFingerprintSize+1, i, maxResults, math.Max(maxDifference, i.maxEntryDifference))
+	results, err := i.Store.GetRoot().FindNearest(entry, rootFingerprintSize+1, i, maxResults, math.Max(maxDifference, i.maxEntryDifference))
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +48,7 @@ func NewIndex(path string, maxFingerprintSize int, maxEntryDifference float64) *
 	os.MkdirAll(path, 0522)
 
 	return &Index{
-		Store:              &DiskIndexStore{},
-		rootNode:           IndexNode{path: path},
+		Store:              &DiskIndexStore{RootPath: path},
 		maxFingerprintSize: maxFingerprintSize,
 		maxEntryDifference: maxEntryDifference,
 	}

--- a/index.go
+++ b/index.go
@@ -10,6 +10,7 @@ import (
 const rootFingerprintSize = 1
 
 type Index struct {
+	Store              IndexStore
 	rootNode           IndexNode
 	maxFingerprintSize int
 	maxEntryDifference float64
@@ -35,7 +36,7 @@ func (i *Index) FindNearest(image image.Image, maxResults int, maxDifference flo
 		return nil, nil
 	}
 
-	results, err := i.rootNode.FindNearest(entry, rootFingerprintSize+1, maxResults, math.Max(maxDifference, i.maxEntryDifference))
+	results, err := i.rootNode.FindNearest(entry, rootFingerprintSize+1, i, maxResults, math.Max(maxDifference, i.maxEntryDifference))
 	if err != nil {
 		return nil, err
 	}
@@ -48,6 +49,7 @@ func NewIndex(path string, maxFingerprintSize int, maxEntryDifference float64) *
 	os.MkdirAll(path, 0522)
 
 	return &Index{
+		Store:              &DiskIndexStore{},
 		rootNode:           IndexNode{path: path},
 		maxFingerprintSize: maxFingerprintSize,
 		maxEntryDifference: maxEntryDifference,

--- a/index.go
+++ b/index.go
@@ -21,7 +21,12 @@ func (i *Index) Add(image image.Image, metadata interface{}) (key string, err er
 		return "", nil
 	}
 
-	node, err := i.Store.GetRoot().Add(entry, rootFingerprintSize+1, i)
+	root, err := i.Store.GetRoot()
+	if err != nil {
+		return "", err
+	}
+
+	node, err := root.Add(entry, rootFingerprintSize+1, i)
 	if err != nil {
 		return "", err
 	}
@@ -35,7 +40,12 @@ func (i *Index) FindNearest(image image.Image, maxResults int, maxDifference flo
 		return nil, nil
 	}
 
-	results, err := i.Store.GetRoot().FindNearest(entry, rootFingerprintSize+1, i, maxResults, math.Max(maxDifference, i.maxEntryDifference))
+	root, err := i.Store.GetRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := root.FindNearest(entry, rootFingerprintSize+1, i, maxResults, math.Max(maxDifference, i.maxEntryDifference))
 	if err != nil {
 		return nil, err
 	}

--- a/index.go
+++ b/index.go
@@ -55,7 +55,7 @@ func (i *Index) FindNearest(image image.Image, maxResults int, maxDifference flo
 }
 
 func NewIndex(path string, maxFingerprintSize int, maxEntryDifference float64) *Index {
-	os.MkdirAll(path, 0522)
+	os.MkdirAll(path, 0700)
 
 	return &Index{
 		Store:              &DiskIndexStore{RootPath: path},

--- a/indexnode.go
+++ b/indexnode.go
@@ -133,32 +133,6 @@ func (node *IndexNode) deleteEntries() error {
 	return os.RemoveAll(entriesDir)
 }
 
-func (node *IndexNode) fingerprintForChild(childPath string) (Fingerprint, error) {
-	childFingerprint := Fingerprint{}
-	childFingerprintFile := filepath.Join(childPath, nodeFingerprintFile)
-
-	file, err := os.Open(childFingerprintFile)
-	if err != nil {
-		return childFingerprint, err
-	}
-	defer file.Close()
-
-	fileInfo, err := file.Stat()
-	if err != nil {
-		return childFingerprint, err
-	}
-
-	fingerprintBytes := make([]byte, fileInfo.Size(), fileInfo.Size())
-	_, err = file.Read(fingerprintBytes)
-	if err != nil {
-		return childFingerprint, err
-	}
-
-	childFingerprint.UnmarshalBytes(fingerprintBytes)
-
-	return childFingerprint, nil
-}
-
 func (node *IndexNode) gatherNearest(entry *IndexEntry, childFingerprintSize int, index *Index, maxDifference float64, results *[]*IndexEntry) error {
 
 	fmt.Printf("%d gatherNearest\n", childFingerprintSize)
@@ -219,16 +193,6 @@ func (node *IndexNode) gatherNearest(entry *IndexEntry, childFingerprintSize int
 	}
 
 	return nil
-}
-
-func (node *IndexNode) loadChild(childDirName string) (*IndexNodeHandle, error) {
-	childPath := filepath.Join(node.path, childDirName)
-	childFingerprint, err := node.fingerprintForChild(childPath)
-	if err != nil {
-		return nil, err
-	}
-
-	return &IndexNodeHandle{Path: childPath, Fingerprint: childFingerprint}, nil
 }
 
 func (node *IndexNode) maxChildDifferenceTo(f Fingerprint) float64 {

--- a/indexnode.go
+++ b/indexnode.go
@@ -37,7 +37,7 @@ func (node *IndexNode) Add(entry *IndexEntry, childFingerprintSize int, index *I
 			node.pushEntriesToChildren(childFingerprintSize)
 
 		} else {
-			err := node.addEntry(entryFingerprint, entry)
+			err := node.addEntry(entry)
 			if err != nil {
 				return nil, err
 			}
@@ -104,7 +104,7 @@ func (node *IndexNode) addSimilarEntriesTo(entries *[]*IndexEntry, fingerprint F
 	})
 }
 
-func (node *IndexNode) addEntry(f Fingerprint, entry *IndexEntry) error {
+func (node *IndexNode) addEntry(entry *IndexEntry) error {
 	entriesDir := filepath.Join(node.path, nodeEntriesDir)
 	os.Mkdir(entriesDir, os.ModePerm)
 
@@ -292,7 +292,7 @@ func (node *IndexNode) pushEntriesToChildren(childFingerprintSize int) error {
 		if err != nil {
 			return err
 		}
-		child.addEntry(entryFingerprint, entry)
+		child.addEntry(entry)
 		return nil
 	})
 

--- a/indexnode.go
+++ b/indexnode.go
@@ -241,7 +241,7 @@ func (node *IndexNode) gatherNearest(entry *IndexEntry, childFingerprintSize int
 			continue
 		}
 
-		childNode, err := index.Store.GetNode(child)
+		childNode, err := index.Store.GetNode(child.Path, child.Fingerprint)
 		if err != nil {
 			return err
 		}

--- a/indexnode.go
+++ b/indexnode.go
@@ -28,7 +28,7 @@ func (node *IndexNode) Add(entry *IndexEntry, childFingerprintSize int, index *I
 
 	entryFingerprint := entry.FingerprintForSize(childFingerprintSize)
 
-	if !node.HasChildren() {
+	if len(node.children) == 0 {
 
 		// We can go deeper and this new entry is sufficiently different to
 		// the rest, so split this leaf node by turning entries into children.
@@ -62,24 +62,6 @@ func (node *IndexNode) FindNearest(entry *IndexEntry, childFingerprintSize int, 
 	}
 
 	return results, nil
-}
-
-func (node *IndexNode) HasChildren() bool {
-	dir, err := os.Open(node.path)
-	if err != nil {
-		return false
-	}
-	defer dir.Close()
-
-	for fileInfos, err := dir.Readdir(1); err == nil && len(fileInfos) > 0; fileInfos, err = dir.Readdir(1) {
-		for _, info := range fileInfos {
-			if info.IsDir() && info.Name() != nodeEntriesDir {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 func (node *IndexNode) addSimilarEntriesTo(entries *[]*IndexEntry, fingerprint Fingerprint, maxDifference float64) error {

--- a/indexnodehandle.go
+++ b/indexnodehandle.go
@@ -1,10 +1,6 @@
 package simian
 
-type indexNodeHandle struct {
-	path        string
-	fingerprint Fingerprint
-}
-
-func (h *indexNodeHandle) Node() *IndexNode {
-	return &IndexNode{path: h.path}
+type IndexNodeHandle struct {
+	Path        string
+	Fingerprint Fingerprint
 }

--- a/indexnodehandle.go
+++ b/indexnodehandle.go
@@ -1,0 +1,10 @@
+package simian
+
+type indexNodeHandle struct {
+	path        string
+	fingerprint Fingerprint
+}
+
+func (h *indexNodeHandle) Node() *IndexNode {
+	return &IndexNode{path: h.path}
+}

--- a/indexstore.go
+++ b/indexstore.go
@@ -1,7 +1,7 @@
 package simian
 
 type IndexStore interface {
-	GetNode(h *IndexNodeHandle) (*IndexNode, error)
+	GetNode(path string, f Fingerprint) (*IndexNode, error)
 	GetRoot() *IndexNode
 	SaveNode(n *IndexNode, f Fingerprint) error
 }

--- a/indexstore.go
+++ b/indexstore.go
@@ -1,7 +1,7 @@
 package simian
 
 type IndexStore interface {
-	GetNode(path string, f Fingerprint) (*IndexNode, error)
-	GetRoot() *IndexNode
+	GetNode(path string) (*IndexNode, error)
+	GetRoot() (*IndexNode, error)
 	SaveNode(n *IndexNode, f Fingerprint) error
 }

--- a/indexstore.go
+++ b/indexstore.go
@@ -1,0 +1,6 @@
+package simian
+
+type IndexStore interface {
+	GetNode(h *IndexNodeHandle) (*IndexNode, error)
+	SaveNode(n *IndexNode, f Fingerprint) error
+}

--- a/indexstore.go
+++ b/indexstore.go
@@ -2,5 +2,6 @@ package simian
 
 type IndexStore interface {
 	GetNode(h *IndexNodeHandle) (*IndexNode, error)
+	GetRoot() *IndexNode
 	SaveNode(n *IndexNode, f Fingerprint) error
 }

--- a/indexstore.go
+++ b/indexstore.go
@@ -1,7 +1,7 @@
 package simian
 
 type IndexStore interface {
-	GetNode(path string) (*IndexNode, error)
+	GetChild(f Fingerprint, parent *IndexNode) (*IndexNode, error)
+	GetOrCreateChild(f Fingerprint, parent *IndexNode) (*IndexNode, error)
 	GetRoot() (*IndexNode, error)
-	SaveNode(n *IndexNode, f Fingerprint) error
 }

--- a/indexstore.go
+++ b/indexstore.go
@@ -1,7 +1,9 @@
 package simian
 
 type IndexStore interface {
+	AddEntry(entry *IndexEntry, node *IndexNode) error
 	GetChild(f Fingerprint, parent *IndexNode) (*IndexNode, error)
 	GetOrCreateChild(f Fingerprint, parent *IndexNode) (*IndexNode, error)
 	GetRoot() (*IndexNode, error)
+	RemoveEntries(node *IndexNode) error
 }


### PR DESCRIPTION
This separates out the node and entry serialisation from the `IndexNode` into an `IndexStore`.

This enables us to properly test the serialisation mechanisms separately from the node traversal parts, and sets us up for changing the storage format for the index.