### PR TITLE
Compact Index Format

### DIFF
--- a/diskindexstore.go
+++ b/diskindexstore.go
@@ -142,12 +142,6 @@ func (s *DiskIndexStore) pathForThumbnail(entry *IndexEntry) string {
 }
 
 func NewDiskIndexStore(rootPath string) (*DiskIndexStore, error) {
-	legacyNodesDir := path.Join(rootPath, "legacy")
-	err := os.MkdirAll(legacyNodesDir, os.FileMode(0700))
-	if err != nil {
-		return nil, err
-	}
-
 	thumbnailsDir := path.Join(rootPath, thumbnailsDir)
 	os.MkdirAll(thumbnailsDir, os.FileMode(0700))
 

--- a/diskindexstore.go
+++ b/diskindexstore.go
@@ -5,15 +5,19 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/mandykoh/keva"
 )
 
 const nodeFingerprintFile = "fingerprint"
 const nodeEntriesDir = "entries"
 
 type DiskIndexStore struct {
-	RootPath string
+	rootPath string
+	nodes    *keva.Store
 }
 
 func (s *DiskIndexStore) AddEntry(entry *IndexEntry, node *IndexNode) error {
@@ -63,7 +67,7 @@ func (s *DiskIndexStore) GetOrCreateChild(f Fingerprint, parent *IndexNode) (*In
 }
 
 func (s *DiskIndexStore) GetRoot() (*IndexNode, error) {
-	return s.getNodeByPath(s.RootPath)
+	return s.getNodeByPath(path.Join(s.rootPath, "legacy"))
 }
 
 func (s *DiskIndexStore) RemoveEntries(node *IndexNode) error {
@@ -214,4 +218,11 @@ func (s *DiskIndexStore) saveNode(n *IndexNode, f Fingerprint) error {
 
 	_, err = file.Write(f.Bytes())
 	return err
+}
+
+func NewDiskIndexStore(rootPath string) *DiskIndexStore {
+	return &DiskIndexStore{
+		rootPath: rootPath,
+		nodes:    keva.NewStore(path.Join(rootPath, "nodes")),
+	}
 }

--- a/diskindexstore.go
+++ b/diskindexstore.go
@@ -53,7 +53,7 @@ func (s *DiskIndexStore) GetOrCreateChild(f Fingerprint, parent *IndexNode) (*In
 
 		node = &IndexNode{
 			path: childPath,
-			childFingerprintsByString: make(map[string]Fingerprint),
+			childFingerprintsByString: make(map[string]*Fingerprint),
 		}
 
 		err := s.saveNode(node, f)
@@ -126,7 +126,7 @@ func (s *DiskIndexStore) getNodeByPath(path string) (*IndexNode, error) {
 
 	node := &IndexNode{
 		path: path,
-		childFingerprintsByString: make(map[string]Fingerprint),
+		childFingerprintsByString: make(map[string]*Fingerprint),
 	}
 
 	err = s.loadAllChildren(node)

--- a/diskindexstore.go
+++ b/diskindexstore.go
@@ -226,18 +226,23 @@ func (s *DiskIndexStore) saveNode(n *IndexNode, f Fingerprint) error {
 	return err
 }
 
-func NewDiskIndexStore(rootPath string) *DiskIndexStore {
+func NewDiskIndexStore(rootPath string) (*DiskIndexStore, error) {
 	legacyNodesDir := path.Join(rootPath, "legacy")
 	err := os.MkdirAll(legacyNodesDir, os.FileMode(0700))
 	if err != nil {
-		fmt.Printf("Error: %v\n", err)
+		return nil, err
 	}
 
 	thumbnailsDir := path.Join(rootPath, thumbnailsDir)
 	os.MkdirAll(thumbnailsDir, os.FileMode(0700))
 
+	nodeStore, err := keva.NewStore(path.Join(rootPath, "nodes"))
+	if err != nil {
+		return nil, err
+	}
+
 	return &DiskIndexStore{
 		rootPath: rootPath,
-		nodes:    keva.NewStore(path.Join(rootPath, "nodes")),
-	}
+		nodes:    nodeStore,
+	}, nil
 }

--- a/diskindexstore.go
+++ b/diskindexstore.go
@@ -53,7 +53,7 @@ func (s *DiskIndexStore) GetOrCreateChild(f Fingerprint, parent *IndexNode) (*In
 
 		node = &IndexNode{
 			path: childPath,
-			childrenByFingerprint: make(map[string]*IndexNodeHandle),
+			childFingerprintsByString: make(map[string]Fingerprint),
 		}
 
 		err := s.saveNode(node, f)
@@ -61,7 +61,7 @@ func (s *DiskIndexStore) GetOrCreateChild(f Fingerprint, parent *IndexNode) (*In
 			return nil, err
 		}
 
-		parent.registerChild(node, f)
+		parent.registerChild(f)
 	}
 
 	return node, nil
@@ -126,7 +126,7 @@ func (s *DiskIndexStore) getNodeByPath(path string) (*IndexNode, error) {
 
 	node := &IndexNode{
 		path: path,
-		childrenByFingerprint: make(map[string]*IndexNodeHandle),
+		childFingerprintsByString: make(map[string]Fingerprint),
 	}
 
 	err = s.loadAllChildren(node)
@@ -157,7 +157,7 @@ func (s *DiskIndexStore) loadAllChildren(n *IndexNode) error {
 					return err
 				}
 
-				n.registerChildByHandle(child)
+				n.registerChild(child)
 			}
 		}
 	}
@@ -197,14 +197,9 @@ func (s *DiskIndexStore) loadAllEntries(n *IndexNode) error {
 	return nil
 }
 
-func (s *DiskIndexStore) loadChild(n *IndexNode, childDirName string) (*IndexNodeHandle, error) {
+func (s *DiskIndexStore) loadChild(n *IndexNode, childDirName string) (Fingerprint, error) {
 	childPath := filepath.Join(n.path, childDirName)
-	childFingerprint, err := s.fingerprintForChild(childPath)
-	if err != nil {
-		return nil, err
-	}
-
-	return &IndexNodeHandle{Path: childPath, Fingerprint: childFingerprint}, nil
+	return s.fingerprintForChild(childPath)
 }
 
 func (s *DiskIndexStore) pathForThumbnail(entry *IndexEntry) string {

--- a/diskindexstore.go
+++ b/diskindexstore.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
-	"strings"
 
 	"github.com/mandykoh/keva"
 )
@@ -21,209 +19,126 @@ type DiskIndexStore struct {
 	nodes    *keva.Store
 }
 
-func (s *DiskIndexStore) AddEntry(entry *IndexEntry, node *IndexNode) error {
-	entriesDir := filepath.Join(node.path, nodeEntriesDir)
-	os.Mkdir(entriesDir, os.ModePerm)
-
-	err := entry.save(entriesDir, s.pathForThumbnail(entry))
+func (s *DiskIndexStore) AddEntry(entry *IndexEntry, node *IndexNode, nodeFingerprint Fingerprint) error {
+	err := entry.saveThumbnail(s.pathForThumbnail(entry))
 	if err != nil {
 		return err
 	}
 
 	node.registerEntry(entry)
-	return nil
+
+	fmt.Printf("AddEntry - Saving [%s] %d %d\n", nodeFingerprint.String(), len(node.childFingerprints), len(node.entries))
+	return s.nodes.Put(nodeFingerprint.String(), node)
+}
+
+func (s *DiskIndexStore) Close() error {
+	return s.nodes.Close()
 }
 
 func (s *DiskIndexStore) GetChild(f Fingerprint, parent *IndexNode) (*IndexNode, error) {
-	path := s.childPathForFingerprint(f, parent.path)
-	return s.getNodeByPath(path)
-}
+	var node IndexNode
 
-func (s *DiskIndexStore) GetOrCreateChild(f Fingerprint, parent *IndexNode) (*IndexNode, error) {
-	fmt.Printf("GetOrCreateChild()\n")
-	childPath := s.childPathForFingerprint(f, parent.path)
+	err := s.nodes.Get(f.String(), &node)
+	if err == keva.ErrValueNotFound {
+		return nil, nil
 
-	node, err := s.getNodeByPath(childPath)
-	if err != nil {
+	} else if err == nil {
+		err = s.loadThumbnails(&node)
+		if err != nil {
+			return nil, err
+		}
+
+	} else {
 		return nil, err
 	}
 
-	if node == nil {
+	return &node, nil
+}
+
+func (s *DiskIndexStore) GetOrCreateChild(f Fingerprint, parent *IndexNode, parentFingerprint Fingerprint) (*IndexNode, error) {
+	fmt.Printf("GetOrCreateChild() %s\n", f.String())
+
+	nodeKey := f.String()
+
+	var node IndexNode
+	err := s.nodes.Get(nodeKey, &node)
+
+	if err == keva.ErrValueNotFound {
 		fmt.Printf("Creating child\n")
 
-		node = &IndexNode{
-			path: childPath,
+		node = IndexNode{
 			childFingerprintsByString: make(map[string]*Fingerprint),
 		}
 
-		err := s.saveNode(node, f)
+		fmt.Printf("GetOrCreateChild - Saving [%s] %d %d\n", nodeKey, len(node.childFingerprints), len(node.entries))
+		err = s.nodes.Put(nodeKey, &node)
 		if err != nil {
 			return nil, err
 		}
 
 		parent.registerChild(f)
+		fmt.Printf("GetOrCreateChild - Parent - Saving [%s] %d %d\n", parentFingerprint.String(), len(parent.childFingerprints), len(parent.entries))
+		err = s.nodes.Put(parentFingerprint.String(), parent)
+		if err != nil {
+			return nil, err
+		}
+
+	} else if err == nil {
+		err = s.loadThumbnails(&node)
+		if err != nil {
+			return nil, err
+		}
+
+	} else {
+		return nil, err
 	}
 
-	return node, nil
+	return &node, nil
 }
 
 func (s *DiskIndexStore) GetRoot() (*IndexNode, error) {
-	return s.getNodeByPath(path.Join(s.rootPath, "legacy"))
-}
+	var rootKey = Fingerprint{}.String()
 
-func (s *DiskIndexStore) RemoveEntries(node *IndexNode) error {
-	entriesDir := filepath.Join(node.path, nodeEntriesDir)
-	err := os.RemoveAll(entriesDir)
-	if err != nil {
-		return err
+	var root IndexNode
+	err := s.nodes.Get(rootKey, &root)
+
+	if err == keva.ErrValueNotFound {
+		fmt.Printf("Root node not found - creating it\n")
+		root = IndexNode{
+			childFingerprintsByString: make(map[string]*Fingerprint),
+		}
+
+	} else if err == nil {
+		fmt.Printf("Found root node with %d children and %d entries\n", len(root.childFingerprints), len(root.entries))
+
+		err = s.loadThumbnails(&root)
+		if err != nil {
+			return nil, err
+		}
+
+	} else {
+		return nil, err
 	}
 
+	return &root, nil
+}
+
+func (s *DiskIndexStore) RemoveEntries(node *IndexNode, nodeFingerprint Fingerprint) error {
 	node.removeEntries()
-	return nil
+	fmt.Printf("RemoveEntries - Saving [%s] %d %d\n", nodeFingerprint.String(), len(node.childFingerprints), len(node.entries))
+	return s.nodes.Put(nodeFingerprint.String(), node)
 }
 
-func (s *DiskIndexStore) childPathForFingerprint(f Fingerprint, parentPath string) string {
-	fingerprintHash := sha256.Sum256(f.Bytes())
-	childDirName := hex.EncodeToString(fingerprintHash[:8])
-	return filepath.Join(parentPath, childDirName)
-}
-
-func (s *DiskIndexStore) fingerprintForChild(childPath string) (Fingerprint, error) {
-	childFingerprint := Fingerprint{}
-	childFingerprintFile := filepath.Join(childPath, nodeFingerprintFile)
-
-	file, err := os.Open(childFingerprintFile)
-	if err != nil {
-		return childFingerprint, err
-	}
-	defer file.Close()
-
-	fileInfo, err := file.Stat()
-	if err != nil {
-		return childFingerprint, err
-	}
-
-	fingerprintBytes := make([]byte, fileInfo.Size(), fileInfo.Size())
-	_, err = file.Read(fingerprintBytes)
-	if err != nil {
-		return childFingerprint, err
-	}
-
-	childFingerprint.UnmarshalBytes(fingerprintBytes)
-
-	return childFingerprint, nil
-}
-
-func (s *DiskIndexStore) getNodeByPath(path string) (*IndexNode, error) {
-
-	_, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	node := &IndexNode{
-		path: path,
-		childFingerprintsByString: make(map[string]*Fingerprint),
-	}
-
-	err = s.loadAllChildren(node)
-	if err != nil {
-		return nil, err
-	}
-
-	err = s.loadAllEntries(node)
-	if err != nil {
-		return nil, err
-	}
-
-	return node, nil
-}
-
-func (s *DiskIndexStore) loadAllChildren(n *IndexNode) error {
-	dir, err := os.Open(n.path)
-	if err != nil {
-		return err
-	}
-	defer dir.Close()
-
-	for fileInfos, err := dir.Readdir(1); err == nil && len(fileInfos) > 0; fileInfos, err = dir.Readdir(1) {
-		for _, info := range fileInfos {
-			if info.IsDir() && info.Name() != nodeEntriesDir {
-				child, err := s.loadChild(n, info.Name())
-				if err != nil {
-					return err
-				}
-
-				n.registerChild(child)
-			}
-		}
-	}
-
-	return nil
-}
-
-func (s *DiskIndexStore) loadAllEntries(n *IndexNode) error {
-	entriesDir := filepath.Join(n.path, nodeEntriesDir)
-
-	dir, err := os.Open(entriesDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	defer dir.Close()
-
-	for fileInfos, err := dir.Readdir(1); err == nil && len(fileInfos) > 0; fileInfos, err = dir.Readdir(1) {
-		for _, fileInfo := range fileInfos {
-			if strings.HasSuffix(fileInfo.Name(), ".entry") {
-				entry, err := NewIndexEntryFromFile(filepath.Join(entriesDir, fileInfo.Name()))
-				if err != nil {
-					return err
-				}
-				err = entry.loadThumbnail(s.pathForThumbnail(entry))
-				if err != nil {
-					return err
-				}
-
-				n.registerEntry(entry)
-			}
-		}
-	}
-
-	return nil
-}
-
-func (s *DiskIndexStore) loadChild(n *IndexNode, childDirName string) (Fingerprint, error) {
-	childPath := filepath.Join(n.path, childDirName)
-	return s.fingerprintForChild(childPath)
+func (s *DiskIndexStore) loadThumbnails(n *IndexNode) error {
+	return n.withEachEntry(func(entry *IndexEntry) error {
+		return entry.loadThumbnail(s.pathForThumbnail(entry))
+	})
 }
 
 func (s *DiskIndexStore) pathForThumbnail(entry *IndexEntry) string {
 	thumbnailHash := sha256.Sum256(entry.MaxFingerprint.Bytes())
 	thumbnailHex := hex.EncodeToString(thumbnailHash[:])
 	return path.Join(s.rootPath, thumbnailsDir, thumbnailHex[0:2], thumbnailHex[2:4], thumbnailHex[4:])
-}
-
-func (s *DiskIndexStore) saveNode(n *IndexNode, f Fingerprint) error {
-	fmt.Printf("Saving node %s\n", n.path)
-
-	os.Mkdir(n.path, os.FileMode(0700))
-
-	// Save the actual (non-truncated) fingerprint
-	fingerprintFile := filepath.Join(n.path, nodeFingerprintFile)
-	file, err := os.Create(fingerprintFile)
-	if err != nil {
-		return err
-	}
-
-	defer file.Close()
-
-	_, err = file.Write(f.Bytes())
-	return err
 }
 
 func NewDiskIndexStore(rootPath string) (*DiskIndexStore, error) {

--- a/fingerprint_test.go
+++ b/fingerprint_test.go
@@ -9,202 +9,205 @@ import (
 	"testing"
 )
 
-func TestBytesSerialisesToPackedBytes(t *testing.T) {
-	f := Fingerprint{samples: []byte{0x00, 0x00, 0xF0, 0xF0}}
+func TestFingerprint(t *testing.T) {
 
-	actualString := fmt.Sprintf("%x", f.Bytes())
+	testImage := func() image.Image {
+		img := image.NewNRGBA(image.Rectangle{Max: image.Point{X: 256, Y: 256}})
 
-	if actualString != "00ff" {
-		t.Errorf("Fingerprint '%s' doesn't match expected", actualString)
-	}
-}
-
-func TestDifferenceReturnsZeroForSameFingerprint(t *testing.T) {
-	f1 := Fingerprint{samples: []byte{0, 1, 2, 3, 130, 255}}
-	f2 := Fingerprint{samples: []byte{0, 1, 2, 3, 130, 255}}
-
-	diff := f1.Difference(f2)
-
-	if diff != 0.0 {
-		t.Errorf("Difference %f doesn't match expected", diff)
-	}
-
-	diff = f2.Difference(f1)
-
-	if diff != 0.0 {
-		t.Errorf("Difference %f doesn't match expected", diff)
-	}
-}
-
-func TestDifferenceReturnsOneForCompletelyDifferentFingerprint(t *testing.T) {
-	f1 := Fingerprint{samples: []byte{0, 0, 0, 255, 255, 255}}
-	f2 := Fingerprint{samples: []byte{255, 255, 255, 0, 0, 0}}
-
-	diff := f1.Difference(f2)
-
-	if diff != 1.0 {
-		t.Errorf("Difference %f doesn't match expected", diff)
-	}
-
-	diff = f2.Difference(f1)
-
-	if diff != 1.0 {
-		t.Errorf("Difference %f doesn't match expected", diff)
-	}
-}
-
-func TestDifferenceReturnsOneForDifferentlySizedFingerprint(t *testing.T) {
-	f1 := Fingerprint{samples: []byte{255, 255, 255}}
-	f2 := Fingerprint{samples: []byte{255, 255, 255, 255}}
-
-	diff := f1.Difference(f2)
-
-	if diff != 1.0 {
-		t.Errorf("Difference %f doesn't match expected", diff)
-	}
-
-	diff = f2.Difference(f1)
-
-	if diff != 1.0 {
-		t.Errorf("Difference %f doesn't match expected", diff)
-	}
-}
-
-func TestDistanceReturnsComponentwiseAbsoluteDifference(t *testing.T) {
-	f1 := Fingerprint{samples: []byte{0, 1, 2, 3, 130, 255}}
-	f2 := Fingerprint{samples: []byte{1, 3, 6, 11, 146, 0}}
-
-	dist := f1.Distance(f2)
-
-	if dist != 286 {
-		t.Errorf("Distance %d doesn't match expected", dist)
-	}
-
-	dist = f2.Distance(f1)
-
-	if dist != 286 {
-		t.Errorf("Distance %d doesn't match expected", dist)
-	}
-}
-
-func TestDistanceReturnsMaxValueForMismatchedLength(t *testing.T) {
-	f1 := Fingerprint{samples: []byte{0, 0, 0}}
-	f2 := Fingerprint{samples: []byte{0, 0, 0, 0}}
-
-	dist := f1.Distance(f2)
-
-	if dist != math.MaxUint64 {
-		t.Errorf("Distance %d wasn't max uint64", dist)
-	}
-}
-
-func TestMarshalTextSerialisesToPackedHexStringBytes(t *testing.T) {
-	f := Fingerprint{samples: []byte{0x00, 0x00, 0xFF, 0xFF}}
-
-	actual, err := f.MarshalText()
-
-	if err != nil {
-		t.Errorf("Error while marshalling: %s", err)
-	}
-	if string(actual) != "00ff" {
-		t.Errorf("Fingerprint '%s' doesn't match expected", actual)
-	}
-}
-
-func TestSizeReturnsCorrectSideLength(t *testing.T) {
-	img := testImage()
-
-	f := NewFingerprint(img, 3)
-	size := f.Size()
-
-	if size != 3 {
-		t.Errorf("Size %d doesn't match expected", size)
-	}
-
-	f = NewFingerprint(img, 7)
-	size = f.Size()
-
-	if size != 7 {
-		t.Errorf("Size %d doesn't match expected", size)
-	}
-
-	f = Fingerprint{samples: make([]byte, 5*5)}
-	size = f.Size()
-
-	if size != 5 {
-		t.Errorf("Size %d doesn't match expected", size)
-	}
-}
-
-func TestStringSerialisesToPackedHexString(t *testing.T) {
-	f := Fingerprint{samples: []byte{
-		0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-		0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-		0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-		0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-		0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-	}}
-
-	actualString := fmt.Sprintf("%s", f)
-
-	if actualString != "fffffffffffffffffffffffff0" {
-		t.Errorf("Fingerprint '%s' doesn't match expected", actualString)
-	}
-}
-
-func TestUnmarshalBytesDeserialisesFromPackedBytes(t *testing.T) {
-	b := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xF0}
-
-	f := Fingerprint{}
-	f.UnmarshalBytes(b)
-
-	if len(f.samples) != 25 {
-		t.Fatalf("Fingerprint length %d doesn't match expected", len(f.samples))
-	}
-	for i := 0; i < 25; i++ {
-		if f.samples[i] != 0xF0 {
-			t.Errorf("Fingerprint byte '%d' doesn't match expected", f.samples[i])
+		for i := img.Bounds().Min.Y; i < img.Bounds().Max.Y; i++ {
+			for j := img.Bounds().Min.X; j < img.Bounds().Max.X; j++ {
+				img.Set(j, i, color.RGBA{uint8(i), uint8(j), uint8(i), 255})
+			}
 		}
+
+		return img
 	}
-}
 
-func TestUnmarshalTextDeserialisesFromPackedHexStringBytes(t *testing.T) {
-	text := []byte("fffffffffffffffffffffffff0")
+	t.Run("Bytes() serialises to packed bytes", func(t *testing.T) {
+		f := Fingerprint{samples: []byte{0x00, 0x00, 0xF0, 0xF0}}
 
-	f := Fingerprint{}
-	f.UnmarshalText(text)
+		actualString := fmt.Sprintf("%x", f.Bytes())
 
-	if len(f.samples) != 25 {
-		t.Fatalf("Fingerprint length %d doesn't match expected", len(f.samples))
-	}
-	for i := 0; i < 25; i++ {
-		if f.samples[i] != 0xF0 {
-			t.Errorf("Fingerprint byte '%d' doesn't match expected", f.samples[i])
+		if actualString != "00ff" {
+			t.Errorf("Fingerprint '%s' doesn't match expected", actualString)
 		}
-	}
-}
+	})
 
-func TestNewFingerprintGeneratesBinaryRepresentation(t *testing.T) {
-	f := NewFingerprint(testImage(), 3)
+	t.Run("Difference() returns zero for same fingerprint", func(t *testing.T) {
+		f1 := Fingerprint{samples: []byte{0, 1, 2, 3, 130, 255}}
+		f2 := Fingerprint{samples: []byte{0, 1, 2, 3, 130, 255}}
 
-	expected, _ := hex.DecodeString("3060805080a070a0c0")
+		diff := f1.Difference(f2)
 
-	expectedString := hex.EncodeToString(expected)
-	actualString := hex.EncodeToString(f.samples)
-
-	if expectedString != actualString {
-		t.Fatalf("Fingerprint '%s' doesn't match expected '%s'", actualString, expectedString)
-	}
-}
-
-func testImage() image.Image {
-	img := image.NewNRGBA(image.Rectangle{Max: image.Point{X: 256, Y: 256}})
-
-	for i := img.Bounds().Min.Y; i < img.Bounds().Max.Y; i++ {
-		for j := img.Bounds().Min.X; j < img.Bounds().Max.X; j++ {
-			img.Set(j, i, color.RGBA{uint8(i), uint8(j), uint8(i), 255})
+		if diff != 0.0 {
+			t.Errorf("Difference %f doesn't match expected", diff)
 		}
-	}
 
-	return img
+		diff = f2.Difference(f1)
+
+		if diff != 0.0 {
+			t.Errorf("Difference %f doesn't match expected", diff)
+		}
+	})
+
+	t.Run("Difference() returns one for completely different fingerprint", func(t *testing.T) {
+		f1 := Fingerprint{samples: []byte{0, 0, 0, 255, 255, 255}}
+		f2 := Fingerprint{samples: []byte{255, 255, 255, 0, 0, 0}}
+
+		diff := f1.Difference(f2)
+
+		if diff != 1.0 {
+			t.Errorf("Difference %f doesn't match expected", diff)
+		}
+
+		diff = f2.Difference(f1)
+
+		if diff != 1.0 {
+			t.Errorf("Difference %f doesn't match expected", diff)
+		}
+	})
+
+	t.Run("Difference() returns one for differently sized fingerprint", func(t *testing.T) {
+		f1 := Fingerprint{samples: []byte{255, 255, 255}}
+		f2 := Fingerprint{samples: []byte{255, 255, 255, 255}}
+
+		diff := f1.Difference(f2)
+
+		if diff != 1.0 {
+			t.Errorf("Difference %f doesn't match expected", diff)
+		}
+
+		diff = f2.Difference(f1)
+
+		if diff != 1.0 {
+			t.Errorf("Difference %f doesn't match expected", diff)
+		}
+	})
+
+	t.Run("Distance() returns componentwise absolute difference", func(t *testing.T) {
+		f1 := Fingerprint{samples: []byte{0, 1, 2, 3, 130, 255}}
+		f2 := Fingerprint{samples: []byte{1, 3, 6, 11, 146, 0}}
+
+		dist := f1.Distance(f2)
+
+		if dist != 286 {
+			t.Errorf("Distance %d doesn't match expected", dist)
+		}
+
+		dist = f2.Distance(f1)
+
+		if dist != 286 {
+			t.Errorf("Distance %d doesn't match expected", dist)
+		}
+	})
+
+	t.Run("Distance() returns max value for mismatched length", func(t *testing.T) {
+		f1 := Fingerprint{samples: []byte{0, 0, 0}}
+		f2 := Fingerprint{samples: []byte{0, 0, 0, 0}}
+
+		dist := f1.Distance(f2)
+
+		if dist != math.MaxUint64 {
+			t.Errorf("Distance %d wasn't max uint64", dist)
+		}
+	})
+
+	t.Run("MarshalText() serialises to packed hex string bytes", func(t *testing.T) {
+		f := Fingerprint{samples: []byte{0x00, 0x00, 0xFF, 0xFF}}
+
+		actual, err := f.MarshalText()
+
+		if err != nil {
+			t.Errorf("Error while marshalling: %s", err)
+		}
+		if string(actual) != "00ff" {
+			t.Errorf("Fingerprint '%s' doesn't match expected", actual)
+		}
+	})
+
+	t.Run("Size() returns correct side length", func(t *testing.T) {
+		img := testImage()
+
+		f := NewFingerprint(img, 3)
+		size := f.Size()
+
+		if size != 3 {
+			t.Errorf("Size %d doesn't match expected", size)
+		}
+
+		f = NewFingerprint(img, 7)
+		size = f.Size()
+
+		if size != 7 {
+			t.Errorf("Size %d doesn't match expected", size)
+		}
+
+		f = Fingerprint{samples: make([]byte, 5*5)}
+		size = f.Size()
+
+		if size != 5 {
+			t.Errorf("Size %d doesn't match expected", size)
+		}
+	})
+
+	t.Run("String() serialises to packed hex string", func(t *testing.T) {
+		f := Fingerprint{samples: []byte{
+			0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+			0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+			0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+			0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+			0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+		}}
+
+		actualString := fmt.Sprintf("%s", f)
+
+		if actualString != "fffffffffffffffffffffffff0" {
+			t.Errorf("Fingerprint '%s' doesn't match expected", actualString)
+		}
+	})
+
+	t.Run("UnmarshalBytes() deserialises from packed bytes", func(t *testing.T) {
+		b := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xF0}
+
+		f := Fingerprint{}
+		f.UnmarshalBytes(b)
+
+		if len(f.samples) != 25 {
+			t.Fatalf("Fingerprint length %d doesn't match expected", len(f.samples))
+		}
+		for i := 0; i < 25; i++ {
+			if f.samples[i] != 0xF0 {
+				t.Errorf("Fingerprint byte '%d' doesn't match expected", f.samples[i])
+			}
+		}
+	})
+
+	t.Run("UnmarshalText() deserialises from packed hex string bytes", func(t *testing.T) {
+		text := []byte("fffffffffffffffffffffffff0")
+
+		f := Fingerprint{}
+		f.UnmarshalText(text)
+
+		if len(f.samples) != 25 {
+			t.Fatalf("Fingerprint length %d doesn't match expected", len(f.samples))
+		}
+		for i := 0; i < 25; i++ {
+			if f.samples[i] != 0xF0 {
+				t.Errorf("Fingerprint byte '%d' doesn't match expected", f.samples[i])
+			}
+		}
+	})
+
+	t.Run("NewFingerprint() generates binary representation", func(t *testing.T) {
+		f := NewFingerprint(testImage(), 3)
+
+		expected, _ := hex.DecodeString("3060805080a070a0c0")
+
+		expectedString := hex.EncodeToString(expected)
+		actualString := hex.EncodeToString(f.samples)
+
+		if expectedString != actualString {
+			t.Fatalf("Fingerprint '%s' doesn't match expected '%s'", actualString, expectedString)
+		}
+	})
 }

--- a/index.go
+++ b/index.go
@@ -16,8 +16,8 @@ type Index struct {
 	maxEntryDifference float64
 }
 
-func (i *Index) Add(image image.Image, metadata interface{}) (key string, err error) {
-	entry, err := NewIndexEntry(image, i.maxFingerprintSize)
+func (i *Index) Add(image image.Image, metadata map[string]interface{}) (key string, err error) {
+	entry, err := NewIndexEntry(image, i.maxFingerprintSize, metadata)
 	if err != nil {
 		return "", nil
 	}
@@ -44,7 +44,9 @@ func (i *Index) Close() error {
 }
 
 func (i *Index) FindNearest(image image.Image, maxResults int, maxDifference float64) ([]*IndexEntry, error) {
-	entry, err := NewIndexEntry(image, i.maxFingerprintSize)
+	var dummy map[string]interface{}
+
+	entry, err := NewIndexEntry(image, i.maxFingerprintSize, dummy)
 	if err != nil {
 		return nil, nil
 	}

--- a/index.go
+++ b/index.go
@@ -1,6 +1,7 @@
 package simian
 
 import (
+	"fmt"
 	"image"
 	"math"
 	"os"
@@ -26,12 +27,20 @@ func (i *Index) Add(image image.Image, metadata interface{}) (key string, err er
 		return "", err
 	}
 
-	node, err := root.Add(entry, rootFingerprintSize+1, i)
+	var rootFingerprint Fingerprint
+
+	_, err = root.Add(entry, rootFingerprint, rootFingerprintSize+1, i)
 	if err != nil {
 		return "", err
 	}
 
-	return node.path, nil
+	fmt.Printf("Root node has %d children and %d entries\n", len(root.childFingerprints), len(root.entries))
+
+	return "", nil
+}
+
+func (i *Index) Close() error {
+	return i.Store.Close()
 }
 
 func (i *Index) FindNearest(image image.Image, maxResults int, maxDifference float64) ([]*IndexEntry, error) {

--- a/index.go
+++ b/index.go
@@ -58,7 +58,7 @@ func NewIndex(path string, maxFingerprintSize int, maxEntryDifference float64) *
 	os.MkdirAll(path, 0700)
 
 	return &Index{
-		Store:              &DiskIndexStore{RootPath: path},
+		Store:              NewDiskIndexStore(path),
 		maxFingerprintSize: maxFingerprintSize,
 		maxEntryDifference: maxEntryDifference,
 	}

--- a/index.go
+++ b/index.go
@@ -54,14 +54,22 @@ func (i *Index) FindNearest(image image.Image, maxResults int, maxDifference flo
 	return results, err
 }
 
-func NewIndex(path string, maxFingerprintSize int, maxEntryDifference float64) *Index {
-	os.MkdirAll(path, 0700)
+func NewIndex(path string, maxFingerprintSize int, maxEntryDifference float64) (*Index, error) {
+	err := os.MkdirAll(path, 0700)
+	if err != nil {
+		return nil, err
+	}
+
+	indexStore, err := NewDiskIndexStore(path)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Index{
-		Store:              NewDiskIndexStore(path),
+		Store:              indexStore,
 		maxFingerprintSize: maxFingerprintSize,
 		maxEntryDifference: maxEntryDifference,
-	}
+	}, err
 }
 
 type entriesByDifferenceToEntry struct {

--- a/indexentry.go
+++ b/indexentry.go
@@ -73,10 +73,10 @@ func (entry *IndexEntry) saveThumbnail(path string) error {
 	return pngEncoder.Encode(thumbnailOut, entry.Thumbnail)
 }
 
-func NewIndexEntry(image image.Image, maxFingerprintSize int) (*IndexEntry, error) {
+func NewIndexEntry(image image.Image, maxFingerprintSize int, attributes map[string]interface{}) (*IndexEntry, error) {
 	entry := &IndexEntry{
 		Thumbnail:  makeThumbnail(image, maxFingerprintSize*2),
-		Attributes: make(map[string]interface{}),
+		Attributes: attributes,
 	}
 
 	entry.MaxFingerprint = entry.FingerprintForSize(maxFingerprintSize)

--- a/indexentry.go
+++ b/indexentry.go
@@ -1,8 +1,6 @@
 package simian
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"image"
 	"image/png"
@@ -15,7 +13,6 @@ import (
 const keyBitLength = 256
 
 type IndexEntry struct {
-	key            string
 	Thumbnail      image.Image
 	MaxFingerprint Fingerprint
 	Attributes     map[string]interface{}
@@ -76,31 +73,8 @@ func (entry *IndexEntry) saveThumbnail(path string) error {
 	return pngEncoder.Encode(thumbnailOut, entry.Thumbnail)
 }
 
-func (entry *IndexEntry) save(path string, thumbnailPath string) error {
-	jsonFile := filepath.Join(path, entry.key+".entry")
-	jsonOut, err := os.Create(jsonFile)
-	if err != nil {
-		return err
-	}
-	defer jsonOut.Close()
-
-	jsonEncoder := json.NewEncoder(jsonOut)
-	err = jsonEncoder.Encode(entry)
-	if err != nil {
-		return err
-	}
-
-	return entry.saveThumbnail(thumbnailPath)
-}
-
 func NewIndexEntry(image image.Image, maxFingerprintSize int) (*IndexEntry, error) {
-	key, err := makeKey()
-	if err != nil {
-		return nil, err
-	}
-
 	entry := &IndexEntry{
-		key:        key,
 		Thumbnail:  makeThumbnail(image, maxFingerprintSize*2),
 		Attributes: make(map[string]interface{}),
 	}
@@ -108,39 +82,6 @@ func NewIndexEntry(image image.Image, maxFingerprintSize int) (*IndexEntry, erro
 	entry.MaxFingerprint = entry.FingerprintForSize(maxFingerprintSize)
 
 	return entry, nil
-}
-
-func NewIndexEntryFromFile(file string) (*IndexEntry, error) {
-	jsonFile, err := os.Open(file)
-	if err != nil {
-		return nil, err
-	}
-	defer jsonFile.Close()
-
-	key := filepath.Base(file)
-	key = key[:(len(key) - len(filepath.Ext(key)))]
-
-	entry := &IndexEntry{
-		key: key,
-	}
-
-	jsonDecoder := json.NewDecoder(jsonFile)
-	err = jsonDecoder.Decode(entry)
-	if err != nil {
-		return nil, err
-	}
-
-	return entry, nil
-}
-
-func makeKey() (string, error) {
-	b := make([]byte, keyBitLength/8)
-	_, err := rand.Read(b)
-	if err != nil {
-		return "", err
-	}
-
-	return hex.EncodeToString(b), nil
 }
 
 func makeThumbnail(src image.Image, size int) image.Image {
@@ -163,6 +104,6 @@ func makeThumbnail(src image.Image, size int) image.Image {
 }
 
 type indexEntryJSON struct {
-	MaxFingerprint []byte `json:"maxFingerprint"`
-	Attributes     map[string]interface{}
+	MaxFingerprint []byte                 `json:"maxFingerprint"`
+	Attributes     map[string]interface{} `json:"attributes"`
 }

--- a/indexentry_test.go
+++ b/indexentry_test.go
@@ -1,0 +1,41 @@
+package simian
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestIndexEntry(t *testing.T) {
+
+	t.Run("JSON serialisation", func(t *testing.T) {
+
+		t.Run("should roundtrip all fields", func(t *testing.T) {
+
+			entry := &IndexEntry{
+				MaxFingerprint: Fingerprint{samples: []uint8{0xF0, 0xF0, 0xF0, 0xF0}},
+				Attributes:     make(map[string]interface{}),
+			}
+			entry.Attributes["some key"] = "some value"
+			entry.Attributes["some other key"] = "some other value"
+
+			jsonBytes, err := json.Marshal(entry)
+			if err != nil {
+				t.Fatalf("Error marshalling JSON: %v", err)
+			}
+
+			var result *IndexEntry
+			err = json.Unmarshal(jsonBytes, &result)
+			if err != nil {
+				t.Fatalf("Error unmarshalling JSON: %v", err)
+			}
+
+			if distance := result.MaxFingerprint.Distance(entry.MaxFingerprint); distance != 0 {
+				t.Errorf("Expected no difference in fingerprints but got %d", distance)
+			}
+			if !reflect.DeepEqual(entry.Attributes, result.Attributes) {
+				t.Errorf("Expected attributes to match but got %v", result.Attributes)
+			}
+		})
+	})
+}

--- a/indexnode.go
+++ b/indexnode.go
@@ -28,7 +28,7 @@ func (node *IndexNode) Add(entry *IndexEntry, nodeFingerprint Fingerprint, child
 		// the rest, so split this leaf node by turning entries into children.
 		fmt.Printf("Max Diff: %f\n", node.maxChildDifferenceTo(entry.MaxFingerprint))
 		if childFingerprintSize < index.maxFingerprintSize && node.maxChildDifferenceTo(entry.MaxFingerprint) > index.maxEntryDifference {
-			fmt.Printf("Pushing entries to children\n")
+			fmt.Printf("Pushing %d entries to children\n", len(node.entries))
 			node.pushEntriesToChildren(nodeFingerprint, childFingerprintSize, index.Store)
 			fmt.Printf("Done pushing entries to children\n")
 
@@ -201,6 +201,7 @@ func (node *IndexNode) pushEntriesToChildren(nodeFingerprint Fingerprint, childF
 		if err != nil {
 			return err
 		}
+		fmt.Printf("Pushing entry to child\n")
 		return store.AddEntry(entry, child, childFingerprint)
 	})
 

--- a/indexnode_test.go
+++ b/indexnode_test.go
@@ -11,7 +11,6 @@ func TestIndexNode(t *testing.T) {
 
 		t.Run("should roundtrip all fields", func(t *testing.T) {
 			n := &IndexNode{
-				path: "some-path",
 				childFingerprintsByString: make(map[string]*Fingerprint),
 			}
 
@@ -39,10 +38,6 @@ func TestIndexNode(t *testing.T) {
 			err = json.Unmarshal(jsonBytes, &result)
 			if err != nil {
 				t.Fatalf("Error unmarshalling JSON: %v", err)
-			}
-
-			if result.path != n.path {
-				t.Errorf("Expected path '%s' but got '%s'", n.path, result.path)
 			}
 
 			if actual, expected := len(result.childFingerprints), len(n.childFingerprints); actual != expected {

--- a/indexnode_test.go
+++ b/indexnode_test.go
@@ -1,0 +1,94 @@
+package simian
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIndexNode(t *testing.T) {
+
+	t.Run("JSON serialisation", func(t *testing.T) {
+
+		t.Run("should roundtrip all fields", func(t *testing.T) {
+			n := &IndexNode{
+				path: "some-path",
+				childFingerprintsByString: make(map[string]*Fingerprint),
+			}
+
+			n.registerChild(Fingerprint{samples: []uint8{0x10, 0x20, 0x30, 0x40}})
+			n.registerChild(Fingerprint{samples: []uint8{0x50, 0x60, 0x70, 0x80}})
+
+			entry1 := &IndexEntry{
+				MaxFingerprint: Fingerprint{samples: []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9}},
+				Attributes:     make(map[string]interface{}),
+			}
+			n.registerEntry(entry1)
+
+			entry2 := &IndexEntry{
+				MaxFingerprint: Fingerprint{samples: []uint8{10, 11, 12, 13, 14, 15, 16, 17, 18}},
+				Attributes:     make(map[string]interface{}),
+			}
+			n.registerEntry(entry2)
+
+			jsonBytes, err := json.Marshal(n)
+			if err != nil {
+				t.Fatalf("Error marshalling JSON: %v", err)
+			}
+
+			var result *IndexNode
+			err = json.Unmarshal(jsonBytes, &result)
+			if err != nil {
+				t.Fatalf("Error unmarshalling JSON: %v", err)
+			}
+
+			if result.path != n.path {
+				t.Errorf("Expected path '%s' but got '%s'", n.path, result.path)
+			}
+
+			if actual, expected := len(result.childFingerprints), len(n.childFingerprints); actual != expected {
+				t.Fatalf("Expected %d child fingerprints but got %d", expected, actual)
+			}
+			for i := 0; i < len(result.childFingerprints); i++ {
+				actual := result.childFingerprints[i].String()
+				expected := n.childFingerprints[i].String()
+
+				if actual != expected {
+					t.Errorf("Expected fingerprint '%s' but got '%s'", expected, actual)
+				}
+			}
+
+			if actual, expected := len(result.childFingerprintsByString), len(n.childFingerprintsByString); actual != expected {
+				t.Fatalf("Expected %d child fingerprints mapped by string but got %d", expected, actual)
+			}
+			for k, v := range n.childFingerprintsByString {
+				actual := result.childFingerprintsByString[k].String()
+				expected := v.String()
+
+				if actual != expected {
+					t.Errorf("Expected fingerprint '%s' but got '%s'", expected, actual)
+				}
+			}
+
+			if actual, expected := len(result.entries), len(n.entries); actual != expected {
+				t.Fatalf("Expected %d entries but got %d", expected, actual)
+			}
+			for i := 0; i < len(result.entries); i++ {
+				actualBytes, err := json.Marshal(result.entries[i])
+				if err != nil {
+					t.Fatalf("Error marshalling entry: %v", err)
+				}
+				actual := string(actualBytes)
+
+				expectedBytes, err := json.Marshal(n.entries[i])
+				if err != nil {
+					t.Fatalf("Error marshalling entry: %v", err)
+				}
+				expected := string(expectedBytes)
+
+				if actual != expected {
+					t.Errorf("Expected entry '%s' but got '%s'", expected, actual)
+				}
+			}
+		})
+	})
+}

--- a/indexnodehandle.go
+++ b/indexnodehandle.go
@@ -1,6 +1,0 @@
-package simian
-
-type IndexNodeHandle struct {
-	Path        string
-	Fingerprint Fingerprint
-}

--- a/indexstore.go
+++ b/indexstore.go
@@ -1,9 +1,10 @@
 package simian
 
 type IndexStore interface {
-	AddEntry(entry *IndexEntry, node *IndexNode) error
+	AddEntry(entry *IndexEntry, node *IndexNode, nodeFingerprint Fingerprint) error
+	Close() error
 	GetChild(f Fingerprint, parent *IndexNode) (*IndexNode, error)
-	GetOrCreateChild(f Fingerprint, parent *IndexNode) (*IndexNode, error)
+	GetOrCreateChild(f Fingerprint, parent *IndexNode, parentFingerprint Fingerprint) (*IndexNode, error)
 	GetRoot() (*IndexNode, error)
-	RemoveEntries(node *IndexNode) error
+	RemoveEntries(node *IndexNode, nodeFingerprint Fingerprint) error
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,18 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "hkHT2pYsqvJVbWqGR3Vt6K0KIUo=",
+			"path": "github.com/mandykoh/keva",
+			"revision": "958f7b64e49598bd87a38c19296c39d56de9d00d",
+			"revisionTime": "2017-08-02T13:19:59Z"
+		},
+		{
+			"checksumSHA1": "fk05LCN5pjUKlw10ErXFIYoFxZk=",
+			"path": "github.com/mandykoh/symlock",
+			"revision": "0362cd091b6b627bf9552d87ba15956d5e8bde32",
+			"revisionTime": "2017-06-17T12:17:10Z"
+		},
+		{
 			"checksumSHA1": "7E3Y1HU/UbsQF/dxMRdjFmx9QDQ=",
 			"path": "golang.org/x/image/draw",
 			"revision": "83686c547965220f8b5d75e83ddc67d73420a89f",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "hkHT2pYsqvJVbWqGR3Vt6K0KIUo=",
+			"checksumSHA1": "3rZWEvKplW9AuWwjuPyCJNyBfhA=",
 			"path": "github.com/mandykoh/keva",
-			"revision": "958f7b64e49598bd87a38c19296c39d56de9d00d",
-			"revisionTime": "2017-08-02T13:19:59Z"
+			"revision": "14866bae2ca726b120aa63fce47e5ac93efb30d0",
+			"revisionTime": "2017-08-12T03:44:41Z"
 		},
 		{
 			"checksumSHA1": "fk05LCN5pjUKlw10ErXFIYoFxZk=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "3rZWEvKplW9AuWwjuPyCJNyBfhA=",
+			"checksumSHA1": "sVE1dlxGDmuS/C6XfTL/2/UG6q4=",
 			"path": "github.com/mandykoh/keva",
-			"revision": "14866bae2ca726b120aa63fce47e5ac93efb30d0",
-			"revisionTime": "2017-08-12T03:44:41Z"
+			"revision": "443c1447fc51d6502cc5cb82d810014baba00b5b",
+			"revisionTime": "2017-08-15T09:38:58Z"
 		},
 		{
 			"checksumSHA1": "fk05LCN5pjUKlw10ErXFIYoFxZk=",


### PR DESCRIPTION
Now that the serialisation has been separated from `IndexNode`, we can begin addressing its various inadequacies, which include:

- Inefficient use of space (2.4GB of actual data took up 38GB of space in one use case).
- Creating large numbers of filesystem objects.
- Difficulty to extend with caching/thread-safety/etc.
- Non-handling of hash collisions.
- Requiring very long filesystem paths.

This work is partly being done as the [Keva](https://github.com/mandykoh/keva) key-value store library.
