### PR TITLE
Add development documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+
+go:
+  - 1.x
+install:
+  - go get github.com/kardianos/govendor
+  - govendor sync
+  - govendor install +local
+script: go test -v -cover ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # simian
 
+[![GoDoc](https://godoc.org/github.com/mandykoh/simian?status.svg)](https://godoc.org/github.com/mandykoh/simian)
+
 Caution—This code is proof-of-concept quality. This means:
 
   * The API is unstable and doesn’t support common use cases.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,22 @@ Caution—This code is proof-of-concept quality. This means:
   * It is not thread safe.
   * Test coverage is mostly non-existant.
   * The current fingerprinting method has known weaknesses which affect quality of results.
+
+Development
+-----------
+
+Simian uses [govendor][govendor] to manage dependencies.
+
+```bash
+go get github.com/mandykoh/simian
+cd $GOPATH/src/github.com/mandykoh/simian
+
+# Install dependencies
+govendor sync
+govendor install +local
+
+# Run the test suite
+go test ./... | grep -v /vendor/
+```
+
+  [govendor]: https://github.com/kardianos/govendor

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # simian
 
 [![GoDoc](https://godoc.org/github.com/mandykoh/simian?status.svg)](https://godoc.org/github.com/mandykoh/simian)
+[![Build Status](https://travis-ci.org/mandykoh/simian.svg?branch=master)](https://travis-ci.org/mandykoh/simian)
 
 A library for image similarity indexing and searching.
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 [![GoDoc](https://godoc.org/github.com/mandykoh/simian?status.svg)](https://godoc.org/github.com/mandykoh/simian)
 
-Caution—This code is proof-of-concept quality. This means:
+A library for image similarity indexing and searching.
 
-  * The API is unstable and doesn’t support common use cases.
-  * The index format is unstable.
-  * It is not thread safe.
-  * Test coverage is mostly non-existant.
-  * The current fingerprinting method has known weaknesses which affect quality of results.
+> **CAUTION**: This code is proof-of-concept quality. This means:
+>
+>  * The API is unstable and doesn’t support common use cases.
+>  * The index format is unstable.
+>  * It is not thread safe.
+>  * Test coverage is mostly non-existant.
+>  * The current fingerprinting method has known weaknesses which affect quality of results.
 
 Development
 -----------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # simian
 
 [![GoDoc](https://godoc.org/github.com/mandykoh/simian?status.svg)](https://godoc.org/github.com/mandykoh/simian)
+[![Go Report Card](https://goreportcard.com/badge/github.com/mandykoh/simian)](https://goreportcard.com/report/github.com/mandykoh/simian)
 [![Build Status](https://travis-ci.org/mandykoh/simian.svg?branch=master)](https://travis-ci.org/mandykoh/simian)
 
 A library for image similarity indexing and searching.

--- a/fingerprint_test.go
+++ b/fingerprint_test.go
@@ -94,7 +94,7 @@ func TestDistanceReturnsMaxValueForMismatchedLength(t *testing.T) {
 	dist := f1.Distance(f2)
 
 	if dist != math.MaxUint64 {
-		t.Errorf("Distance %f wasn't max uint64", dist)
+		t.Errorf("Distance %d wasn't max uint64", dist)
 	}
 }
 


### PR DESCRIPTION
**When I** discover simian 
**I want** to find some development documentation 
**So that** it is easier for me to get started 
**And** I know the project maintainer(s) care about contributions 

@mandykoh I did a [proof-of-concept Travis CI setup][ci] from my fork.
If you like it, in order for this repository to be built automatically by Travis, you would need to:

- sign up in [Travis CI](https://travis-ci.org/) - relies on Github OAuth
- add this repo to your account (it's a switch, Travis CI supports open-source projects for free)
- push again to this branch (eventually `--force`-pushing the last commit again) to trigger a build

The badge in the README is already pointing to that hypothetical account of yours ; )
Also two Travis-related commits are standalone anyway so it's easy to edit or remove them.

  [ci]: https://travis-ci.org/gonzalo-bulnes/simian