### PR TITLE
Fingerprint Bitmask Fix

### DIFF
--- a/fingerprint.go
+++ b/fingerprint.go
@@ -11,7 +11,7 @@ import (
 )
 
 const bitsPerSample = 4
-const sampleBitsMask = (2 << bitsPerSample) - 1
+const sampleBitsMask = (1 << bitsPerSample) - 1
 const samplesPerByte = 8 / bitsPerSample
 
 type Fingerprint struct {
@@ -118,7 +118,7 @@ func NewFingerprint(src image.Image, size int) Fingerprint {
 			r, g, b, _ := scaled.At(j, i).RGBA()
 			y, _, _ := color.RGBToYCbCr(uint8(r>>8), uint8(g>>8), uint8(b>>8))
 
-			fingerprintSamples[offset] = y & 0xC0
+			fingerprintSamples[offset] = y & (sampleBitsMask << (8 - bitsPerSample))
 			offset++
 		}
 	}

--- a/fingerprint_test.go
+++ b/fingerprint_test.go
@@ -187,7 +187,7 @@ func TestUnmarshalTextDeserialisesFromPackedHexStringBytes(t *testing.T) {
 func TestNewFingerprintGeneratesBinaryRepresentation(t *testing.T) {
 	f := NewFingerprint(testImage(), 3)
 
-	expected, _ := hex.DecodeString("0040804080804080c0")
+	expected, _ := hex.DecodeString("3060805080a070a0c0")
 
 	expectedString := hex.EncodeToString(expected)
 	actualString := hex.EncodeToString(f.samples)


### PR DESCRIPTION
This corrects the number of bits of image data used per sample when creating a fingerprint from an image.